### PR TITLE
Some fixes to 01 journey

### DIFF
--- a/.journey/01-build.neos.md
+++ b/.journey/01-build.neos.md
@@ -78,7 +78,7 @@ RUN CGO_ENABLED=0 go build -v -o server
 CMD ["/app/server"]
 ```
 This Dockerfile:
-1. uses Debian Bullseye with Golang 1.19 as base image
+1. uses Debian Bullseye with Golang 1.20 as base image
 2. copies the definition of the Go module and installs all dependencies
 3. copies the sources and builds the Go application
 4. specifies the application binary to run

--- a/.journey/01-build.neos.md
+++ b/.journey/01-build.neos.md
@@ -240,6 +240,9 @@ First, navigate to the [Cloud Build triggers section of the Google Cloud Console
 
 Now, hit 'Create Trigger' and create a new trigger. In the wizard, specify that the trigger should read configuration from the provided './cloudbuild.yaml' and **add all the substitutions** you used previously to trigger your build.
 
+**Note:** When using the "Autodetect" configuration option, there is no possibility to add substituiton variables through the UI. So make sure to specify the "Cloud Build configuration file (yaml or json)" option explicitly, and then continue to fill in the substition variables.
+
+
 ### Pushing some changes
 
 We should now have everything in place to automatically trigger a new build whenever changes are pushed to `main` on the remote repository fork.


### PR DESCRIPTION
- Updated version of go in description to match the version in the code sample above
- Added note on the trigger configuration. When using "Autodetect" to detected the cloudbuild.yaml file, the UI doesn't allow for variable substitutions. 