### PR TITLE
Fixed a broken link in the tutorial

### DIFF
--- a/.journey/tutorial.neos.md
+++ b/.journey/tutorial.neos.md
@@ -305,7 +305,7 @@ control over how we build our images. Finally, we'll use Cloud Build to also
 deploy to Cloud Run, so we can continuously deliver updates to our Cloud Run
 services.
 
-[Overview on Cloud Build](https://raw.githubusercontent.com/NucleusEngineering/serverless/main/.images/overview-build.jpg)
+[Overview on Cloud Build](https://raw.githubusercontent.com/NucleusEngineering/serverless/main/.images/overview-build.png)
 
 <walkthrough-tutorial-difficulty difficulty="3"></walkthrough-tutorial-difficulty>
 


### PR DESCRIPTION
The link in the tutorial for the overview on Cloud Build was pointing to a jpg image but the image in the repository for Cloud Build is a png file. This should fix it.